### PR TITLE
Adds support for relative paths via templatesPath configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ out
 node_modules
 .tags
 /package-lock.json
+.vscode-test

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
         "url": "https://github.com/DengSir/template-generator-vscode.git"
     },
     "engines": {
-        "vscode": "^1.12.0"
+        "vscode": "^1.12.0",
+        "node": "^14.0.0"
     },
     "categories": [
         "Other"
@@ -90,17 +91,17 @@
     "scripts": {
         "vscode:prepublish": "tsc -p ./",
         "compile": "tsc -watch -p ./",
-        "postinstall": "node ./node_modules/vscode/bin/install",
-        "test": "node ./node_modules/vscode/bin/test"
+        "test": "node ./out/src/test/runTest.js"
     },
     "devDependencies": {
         "@types/lodash": "^4.14.99",
         "@types/mocha": "^2.2.48",
         "@types/mz": "0.0.32",
-        "@types/node": "^9.4.0",
+        "@types/node": "^14.0.0",
+        "@types/vscode": "^1.12.0",
         "mocha": "^5.0.0",
-        "typescript": "^2.6.2",
-        "vscode": "^1.1.10"
+        "typescript": "^4.1.5",
+        "vscode-test": "^1.5.0"
     },
     "dependencies": {
         "@types/mkdirp": "^0.5.2",

--- a/src/environment.ts
+++ b/src/environment.ts
@@ -90,11 +90,21 @@ export class Environment {
     }
 
     public get templatesFolderPath(): string {
-        return this.config.get<string>('templatesPath') || path.join(os.homedir(), '.vscode/templates');
+        const configPath = this.config.get<string>('templatesPath') || path.join(os.homedir(), '.vscode/templates');
+
+        if (!path.isAbsolute(configPath) && this.workspaceRoot) {
+            return path.join(this.workspaceRoot, configPath)
+        }
+
+        return configPath
     }
 
     public set fileName(fileName: string) {
         this.fields.name = fileName;
+    }
+
+    private get workspaceRoot(): string | undefined {
+        return (vscode.workspace.workspaceFolders || [])[0]?.uri?.fsPath
     }
 }
 

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -1,0 +1,24 @@
+import * as path from 'path';
+
+import { runTests } from 'vscode-test';
+
+async function main() {
+  try {
+    // The folder containing the Extension Manifest package.json
+    // Passed to `--extensionDevelopmentPath`
+    const extensionDevelopmentPath = path.resolve(__dirname, '../../../');
+
+    // The path to the extension test runner script
+    // Passed to --extensionTestsPath
+    const extensionTestsPath = path.resolve(__dirname, './suite/index');
+
+    // Download VS Code, unzip it and run the integration test
+    await runTests({ extensionDevelopmentPath, extensionTestsPath });
+  } catch (err) {
+    console.error(err);
+    console.error('Failed to run tests');
+    process.exit(1);
+  }
+}
+
+main();

--- a/src/util.ts
+++ b/src/util.ts
@@ -33,7 +33,7 @@ function copyFile(src, dst) {
                 if (err) {
                     reject(err);
                 } else {
-                    resolve();
+                    resolve(undefined);
                 }
             });
     });


### PR DESCRIPTION
So the problem I'm trying to address with this PR came up using this extension like this in this project:

![image](https://user-images.githubusercontent.com/1484824/107765005-003cbf80-6d29-11eb-9cd0-a26a706e277e.png)

The idea was to enable to just commit a sample `.vscode/settings.json` file that "just worked"™. The problem we faced had to do with the fact the extension would, sometimes, not work with a relative `templatesPath` configuration.

The expectation was that opening the project as a workspace + using a relative path on the settings file, would make the extension look for templates from the `workspaceRoot`. Turns out that it was resolving the relative path from vscode's `process.cwd()`, which == to whatever directory you've launched the first instance of vscode from.

This PR introduces the following changes:

* Bumps NodeJS engine version requirement (corresponding typings) and Typescript (I struggled a bit to compile the project)
* Deprecates `vscode` package according to [this documentation](https://code.visualstudio.com/api/working-with-extensions/testing-extension#migrating-from-vscode)
* Makes the extension to try to resolve the templates path from the `workspaceRoot`, if a relative path is provided

I tried to find a way to enable variable substitution to work (so that `"templatesPath": "${workspaceFolder}/.vscode/templates"` would work for example), but [AFAIK](https://github.com/microsoft/vscode/issues/2809) it doesn't appear to exist a public API yet for this. So I went with a simpler route.

This is my first time contributing to a vscode extension, so let me know if something feels fishy (I'm more than happy to patch it up to get this through).

Hopefully will mitigate #6 .